### PR TITLE
Bump log4j-core

### DIFF
--- a/2_Device_Connectivity_Management/lab_tutorial/smartbattery_samplejavaproject/pom.xml
+++ b/2_Device_Connectivity_Management/lab_tutorial/smartbattery_samplejavaproject/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.7</version>
+            <version>2.16.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumps log4j-core from 2.7 to 2.16.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>